### PR TITLE
feat: Add initial functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Role Variables
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-------:|:--------:|
-| name | desc | type | default | required |
+| `fips_in_container` | This task will not work inside of containers | boolean | `false` | `false` |
+| `fips_grub_cmdline` | GRUB command line to specify FIPS | string | `GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0   net.ifnames=0 rd.blacklist=nouveau crashkernel=auto boot=/dev/xvda2 fips=1  "` | `false` |
+| `fips_grub_file` | Default GRUB file | string | `/etc/default/grub` | `false` |
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,4 @@
 ---
+fips_in_container: false
+fips_grub_cmdline: 'GRUB_CMDLINE_LINUX="console=ttyS0,115200n8 console=tty0 net.ifnames=0 rd.blacklist=nouveau crashkernel=auto boot=/dev/xvda2 fips=1"'
+fips_grub_file: /etc/default/grub

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -4,3 +4,5 @@
   hosts: all
   roles:
     - role: ansible-role-fips
+      vars:
+        fips_in_container: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: ubi8
-    image: registry.redhat.io/ubi8
+  - name: debian9
+    image: debian:9
 provisioner:
   name: ansible
 verifier:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,8 @@ lint: |
   ansible-lint
   flake8
 platforms:
-  - name: debian9
-    image: debian:9
+  - name: ubi8
+    image: registry.redhat.io/ubi8
 provisioner:
   name: ansible
 verifier:

--- a/tasks/fips.yml
+++ b/tasks/fips.yml
@@ -1,0 +1,21 @@
+---
+- name: Check if FIPS is enabled
+  command: cat /proc/sys/crypto/fips_enabled
+  register: fips
+  changed_when: false
+
+- name: Edit GRUB file to enable FIPS
+  lineinfile:
+    path: "{{ fips_grub_file }}"
+    regexp: '^GRUB_CMDLINE_LINUX'
+    line: "{{ fips_grub_cmdline }}"
+
+- name: Generate GRUB config file
+  shell: |
+    grub2-mkconfig -o /etc/grub2.cfg
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+  when: fips.stdout == 0
+
+- name: Reboot
+  reboot:
+  when: fips.stdout == 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,1 +1,4 @@
 ---
+- name: Don't run in containers
+  include_tasks: fips.yml
+  when: not fips_in_container


### PR DESCRIPTION
### Description

This will enable FIPS on compatible hosts. 
Specifically, it will add `boot=/dev/xvda2 fips=1` to the end of the `GRUB_CMDLINE_LINUX` environment variable for GRUB,
recreate the GRUB config using:
```
grub2-mkconfig -o /etc/grub2.cfg
grub2-mkconfig -o /boot/grub2/grub.cfg
```
And then reboot the machine. This role will not work in a container.
To check if FIPS is enabled, run:
```
cat /proc/sys/crypto/fips_enabled # should equal 0
sysctl crypto.fips_enabled # should say enabled
```